### PR TITLE
Fixed outdated download selector in soundsnap userscript

### DIFF
--- a/soundsnap-downloader.user.js
+++ b/soundsnap-downloader.user.js
@@ -39,7 +39,7 @@
         // =========================
         const tracks = document.querySelectorAll("div.ojoo-teaser");
         tracks.forEach((track) => {
-            const downloadButton = track.querySelector("a.ss_icons.ss_download");
+            const downloadButton = track.querySelector("a.button-icon.teaser-icons.primary.ojoo-icon-download");
             console.log(downloadButton);
             downloadButton.removeAttribute("href");
             downloadButton.addEventListener("click", () => {


### PR DESCRIPTION
Tried using your soundsnap userscript and it wasn't working so I checked the code and console logs and noticed it was failing to find the old download button selector `a.ss_icons.ss_download` , I fixed it with the new selector `a.button-icon.teaser-icons.primary.ojoo-icon-download` and the script worked perfectly!

Creating a pull request for ease of use by others.